### PR TITLE
fix(bootstrap): support environment id

### DIFF
--- a/bin/commands/bootstrap.js
+++ b/bin/commands/bootstrap.js
@@ -29,12 +29,25 @@ exports.builder = (yargs) => {
       requiresArg: true,
       demandOption: true
     })
+    .option('environment-id', {
+      alias: 'e',
+      describe: 'id of the environment within the space',
+      type: 'string',
+      requiresArg: true,
+      default: 'master'
+    })
     .option('danger-will-robinson-danger', {
       describe: 'delete all current migrations and create already-applied states for all content types in space'
     });
 };
 
-exports.handler = ({ spaceId, dangerWillRobinsonDanger, accessToken }) => {
+exports.handler = (args) => {
+  const {
+    environmentId,
+    spaceId,
+    dangerWillRobinsonDanger,
+    accessToken
+  } = args;
   const migrationsDirectory = path.join('.', 'migrations');
 
   if (dangerWillRobinsonDanger) {
@@ -53,11 +66,11 @@ exports.handler = ({ spaceId, dangerWillRobinsonDanger, accessToken }) => {
         process.exit(1);
       }
       console.log(chalk.bold.green('🤞  May the 🐴 be with you'));
-      bootstrap(spaceId, accessToken, migrationsDirectory, dangerWillRobinsonDanger);
+      bootstrap(spaceId, environmentId, accessToken, migrationsDirectory, dangerWillRobinsonDanger);
     });
     /* eslint-enable no-console */
   } else {
-    bootstrap(spaceId, accessToken, migrationsDirectory);
+    bootstrap(spaceId, environmentId, accessToken, migrationsDirectory);
   }
 };
 

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -6,15 +6,15 @@ const generateScripts = require('./bootstrap/generateScripts');
 const deleteScripts = require('./bootstrap/deleteScripts');
 const rewriteMigration = require('./bootstrap/rewriteMigration');
 
-const bootstrap = (spaceId, accessToken, migrationsDirectory, robinson) => {
+const bootstrap = (spaceId, environmentId, accessToken, migrationsDirectory, robinson) => {
   if (!robinson) {
-    return generateScripts(spaceId, accessToken, migrationsDirectory)
+    return generateScripts(spaceId, environmentId, accessToken, migrationsDirectory)
       .then(() => log(chalk.bold.green('🎉  Bootstrap'), chalk.bold.green('successful')))
       .catch(error => logError('🚨  Failed to generate scripts', error));
   }
   return deleteScripts(migrationsDirectory)
-    .then(() => generateScripts(spaceId, accessToken, migrationsDirectory))
-    .then(files => rewriteMigration(spaceId, accessToken, files))
+    .then(() => generateScripts(spaceId, environmentId, accessToken, migrationsDirectory))
+    .then(files => rewriteMigration(spaceId, environmentId, accessToken, files))
     .then(() => log(chalk.bold.green('🎉  Bootstrap'), chalk.bold.green('successful')))
     .catch(error => logError('🚨  Failed to perform bootstrap', error));
 };

--- a/lib/bootstrap/generateScripts.js
+++ b/lib/bootstrap/generateScripts.js
@@ -5,11 +5,12 @@ const log = require('migrate/lib/log');
 const createFile = require('./createFile');
 const { jsonToScript } = require('./jsonToScript');
 
-const generateScripts = (spaceId, accessToken, migrationsDirectory) => {
+const generateScripts = (spaceId, environmentId, accessToken, migrationsDirectory) => {
   const client = contentful.createClient({ accessToken });
   return client.getSpace(spaceId)
+    .then(space => space.getEnvironment(environmentId))
     // TODO: add pagination when content type exceeds 1000
-    .then(space => space.getContentTypes({ limit: 1000 }))
+    .then(environment => environment.getContentTypes({ limit: 1000 }))
     .then(response => response.items.filter(item => item.sys.id !== 'migration'))
     .then(items => Promise.all(items.map((item) => {
       return createFile(item.sys.id, jsonToScript(item), migrationsDirectory);

--- a/lib/bootstrap/rewriteMigration.js
+++ b/lib/bootstrap/rewriteMigration.js
@@ -2,8 +2,8 @@ const log = require('migrate/lib/log');
 
 const { createStoreFactory } = require('../store');
 
-const rewriteMigration = async (spaceId, accessToken, files) => {
-  const factory = await createStoreFactory({ accessToken, spaceId });
+const rewriteMigration = async (spaceId, environmentId, accessToken, files) => {
+  const factory = await createStoreFactory({ accessToken, environmentId, spaceId });
 
   return Promise.all(files.map((file) => {
     const contentType = file.contentTypeId;


### PR DESCRIPTION
Hi,

Thanks for the awesome tool. However I did notice the bootstrap feature is currently not supporting environments and using it for initializing migration state results in a 404 error since environment id is not defined. Here's my attempt at fixing it.