### PR TITLE
fix: updated migrate package due to vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "listr": "^0.13.0",
     "lodash.reduce": "^4.6.0",
-    "migrate": "^1.0.0",
+    "migrate": "^1.6.2",
     "mkdirp": "^0.5.1",
     "p-map": "^1.2.0",
     "rimraf": "^2.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -387,9 +387,14 @@ colors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
-commander@2.15.1, commander@^2.9.0:
+commander@2.15.1:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+
+commander@^2.9.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
 compare-func@^1.3.1:
   version "1.3.2"
@@ -590,6 +595,7 @@ dot-prop@^3.0.0:
 dotenv@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
+  integrity sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -1390,9 +1396,10 @@ meow@^3.3.0, meow@^3.7.0:
     redent "^1.0.0"
     trim-newlines "^1.0.0"
 
-migrate@^1.0.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/migrate/-/migrate-1.5.0.tgz#7c42d8a50b84265c6c2f4d05763e37840a370ce2"
+migrate@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/migrate/-/migrate-1.6.2.tgz#8970d596780553fe9f545bdf83806df8473f025b"
+  integrity sha512-XAFab+ArPTo9BHzmihKjsZ5THKRryenA+lwob0R+ax0hLDs7YzJFJT5YZE3gtntZgzdgcuFLs82EJFB/Dssr+g==
   dependencies:
     chalk "^1.1.3"
     commander "^2.9.0"
@@ -1401,7 +1408,7 @@ migrate@^1.0.0:
     inherits "^2.0.3"
     minimatch "^3.0.3"
     mkdirp "^0.5.1"
-    slug "^0.9.1"
+    slug "^0.9.2"
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -1893,9 +1900,10 @@ slice-ansi@1.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
 
-slug@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/slug/-/slug-0.9.1.tgz#af08f608a7c11516b61778aa800dce84c518cfda"
+slug@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/slug/-/slug-0.9.2.tgz#e409e4dae3a4bd2fd283557e2806e0a8abb98242"
+  integrity sha512-WULwxWq6NBM/i24pV9st/WI9TwzjXYpNzxbWr9mRDj74Lqwb3ahsnWsWJtXHfBPpBqXb4m1hYt9S7eMyDkZsKA==
   dependencies:
     unicode ">= 0.3.1"
 
@@ -2096,8 +2104,9 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 "unicode@>= 0.3.1":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/unicode/-/unicode-10.0.0.tgz#e5d51c1db93b6c71a0b879e0b0c4af7e6fdf688e"
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/unicode/-/unicode-11.0.1.tgz#735bd422ec75cf28d396eb224d535d168d5f1db6"
+  integrity sha512-+cHtykLb+eF1yrSLWTwcYBrqJkTfX7Quoyg7Juhe6uylF43ZbMdxMuSHNYlnyLT8T7POAvavgBthzUF9AIaQvQ==
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Running NSP on my project, I found a vulnerability with one of the dependencies: migrate.  I've updated this dependency to the latest version which should fix this.

Fix is found in version 1.6.2 of migrate

https://nodesecurity.io/advisories/537