### PR TITLE
Provide --compiler flag for `up`, `down`, `list`

### DIFF
--- a/bin/commands/down.js
+++ b/bin/commands/down.js
@@ -5,6 +5,7 @@ const path = require('path')
 const runMigrations = require('migrate/lib/migrate')
 const log = require('migrate/lib/log')
 const load = require('../../lib/load')
+const registerCompiler = require('migrate/lib/register-compiler')
 
 exports.command = 'down [file]'
 
@@ -40,6 +41,11 @@ exports.builder = (yargs) => {
       describe: 'single content type name to process',
       demandOption: true
     })
+    .option('compiler', {
+      describe: 'compiler to add, e.g. "ts:./tsnode.js"',
+      type: 'string',
+      requiresArg: false
+    })
     .option('dry-run', {
       alias: 'd',
       describe: 'only shows the planned actions, don\'t write anything to Contentful',
@@ -59,8 +65,12 @@ exports.handler = async (args) => {
     dryRun,
     environmentId,
     file,
-    spaceId
+    spaceId,
+    compiler
   } = args
+  if (compiler) {
+    registerCompiler(compiler)
+  }
 
   const migrationsDirectory = path.join('.', 'migrations')
 

--- a/bin/commands/list.js
+++ b/bin/commands/list.js
@@ -6,6 +6,7 @@ const chalk = require('chalk')
 const dateFormat = require('dateformat')
 const log = require('migrate/lib/log')
 const load = require('../../lib/load')
+const registerCompiler = require('migrate/lib/register-compiler')
 
 exports.command = 'list'
 
@@ -42,6 +43,11 @@ exports.builder = (yargs) => {
       array: true,
       default: []
     })
+    .option('compiler', {
+      describe: 'compiler to add, e.g. "ts:./tsnode.js"',
+      type: 'string',
+      requiresArg: false
+    })
     .option('all', {
       alias: 'a',
       describe: 'lists migrations for all content types',
@@ -59,8 +65,12 @@ exports.builder = (yargs) => {
 }
 
 exports.handler = async ({
-  spaceId, environmentId, contentType, accessToken
+  spaceId, environmentId, contentType, accessToken, compiler
 }) => {
+  if (compiler) {
+    registerCompiler(compiler)
+  }
+
   const migrationsDirectory = path.join('.', 'migrations')
 
   const listSet = (set) => {

--- a/bin/commands/up.js
+++ b/bin/commands/up.js
@@ -9,6 +9,7 @@ const pMap = require('p-map')
 const runMigrations = require('migrate/lib/migrate')
 const log = require('migrate/lib/log')
 const load = require('../../lib/load')
+const registerCompiler = require('migrate/lib/register-compiler')
 
 exports.command = 'up [file]'
 
@@ -44,6 +45,11 @@ exports.builder = (yargs) => {
       describe: 'one or more content type names to process',
       array: true,
       default: []
+    })
+    .option('compiler', {
+      describe: 'compiler to add, e.g. "ts:./tsnode.js"',
+      type: 'string',
+      requiresArg: false
     })
     .option('all', {
       alias: 'a',
@@ -83,8 +89,12 @@ exports.handler = async (args) => {
     dryRun,
     environmentId,
     file,
-    spaceId
+    spaceId,
+    compiler
   } = args
+  if (compiler) {
+    registerCompiler(compiler)
+  }
 
   const migrationsDirectory = path.join('.', 'migrations')
 


### PR DESCRIPTION
This allows folks to write migrations in TypeScript, with a setup like the following:

- A file `migrations/tsnode.js` containing a require-able module:

```javascript
require("ts-node/register")
module.exports = () => {}
```

  See https://github.com/tj/node-migrate/issues/108#issuecomment-371107685 for more here.

- A command-line argument to register the ts extension with ts-node:

```bash
$ ctf-migrate list --compiler "ts:./migrations/tsnode.js" \
    --space-id $CONTENTFUL_SPACE_ID \
    --environment-id $CONTENTFUL_ENVIRONMENT_ID \
    --access-token $CONTENTFUL_MANAGEMENT_ACCESS_TOKEN 
    -a
```

And just to reiterate some of the tradeoffs I see from the related issue (#53):

#### Pros

- Gets TypeScript migrations working.
- Fairly uninvasive.

#### Cons

- Requires users to add a file, and point to it from the command-line argument. We could alternatively make the contentful-migrate flag be from more of a closed set to make it user-friendlier (e.g. something like --compiler typescript), but I'm more inclined to leave it open to extension in letting more options besides typescript potentially work.
- May mean breaking changes if/when tj/node-migrate changes their API, although they're already thinking/talking about handling breaking changes with major version bumps.
- Opens up questions about whether the migration codegen should support TypeScript.

No worries if you want to go a different way - just figured showing the code might be easier than talking about it (also might save others some time).