### PR TITLE
Replace deprecated changeEditorInterface method

### DIFF
--- a/lib/bootstrap/__tests__/jsonToScript.spec.js
+++ b/lib/bootstrap/__tests__/jsonToScript.spec.js
@@ -2,7 +2,7 @@ const expect = require('expect.js')
 const {
   removeNullValues,
   rejectEmptyObjects,
-  createChangeEditorInterface,
+  createChangeFieldControl,
   restructureFields,
   restructureContentTypeJson,
   jsonToScript
@@ -74,26 +74,26 @@ describe('rejectEmptyObjects', () => {
   })
 })
 
-describe('createChangeEditorInterface', () => {
-  it('creates changeEditorInterface without settings', () => {
+describe('createChangeFieldControl', () => {
+  it('creates changeFieldControl without settings', () => {
     const itemId = 'myModel'
     const field = { fieldId: 'unicornDestroyer', widgetId: 'number' }
 
-    const changeEditorInterface = createChangeEditorInterface(itemId, field)
-    const expected = 'myModel.changeEditorInterface("unicornDestroyer", "number");'
-    expect(changeEditorInterface).to.equal(expected)
+    const changeFieldControl = createChangeFieldControl(itemId, field)
+    const expected = 'myModel.changeFieldControl("unicornDestroyer", "builtin", "number");'
+    expect(changeFieldControl).to.equal(expected)
   })
 
-  it('creates changeEditorInterface with settings', () => {
+  it('creates changeFieldControl with settings', () => {
     const itemId = 'myModel'
     const field = {
       fieldId: 'pegasusLauncher',
       widgetId: 'radio',
       settings: { parts: 'button' }
     }
-    const changeEditorInterface = createChangeEditorInterface(itemId, field)
-    const expected = 'myModel.changeEditorInterface("pegasusLauncher", "radio", {"parts":"button"});'
-    expect(changeEditorInterface).to.equal(expected)
+    const changeFieldControl = createChangeFieldControl(itemId, field)
+    const expected = 'myModel.changeFieldControl("pegasusLauncher", "builtin", "radio", {"parts":"button"});'
+    expect(changeFieldControl).to.equal(expected)
   })
 })
 

--- a/lib/bootstrap/jsonToScript.js
+++ b/lib/bootstrap/jsonToScript.js
@@ -29,16 +29,16 @@ const createField = (itemId, field) => `
   ${itemId}.createField("${field.id}")${''.concat(...Object.entries(field.props).filter(rejectEmptyObjects).map(createProp))};
 `
 
-const createChangeEditorInterface = (itemId, field) => {
+const createChangeFieldControl = (itemId, field) => {
   const { fieldId, widgetId, settings } = field
-  const baseString = `${itemId}.changeEditorInterface("${fieldId}", "${widgetId}"`
+  const baseString = `${itemId}.changeFieldControl("${fieldId}", "builtin", "${widgetId}"`
   return settings ? `${baseString}, ${JSON.stringify(settings)});` : `${baseString});`
 }
 
 const createContentType = (item, editorInterface) => `
   const ${item.id} = migration.createContentType('${item.id}')${''.concat(...Object.entries(item.props).map(createProp))};
   ${''.concat(...item.fields.map(field => createField(item.id, field)))}
-  ${editorInterface.map(field => createChangeEditorInterface(item.id, field)).join('\n')}
+  ${editorInterface.map(field => createChangeFieldControl(item.id, field)).join('\n')}
 `
 
 const createScript = (item, editorInterface) => `module.exports.description = "Create content model for ${item.props.name}";
@@ -77,7 +77,7 @@ const jsonToScript = (contentTypeJson, editorInterface) => {
 module.exports = {
   removeNullValues,
   rejectEmptyObjects,
-  createChangeEditorInterface,
+  createChangeFieldControl,
   restructureFields,
   restructureContentTypeJson,
   jsonToScript


### PR DESCRIPTION
This PR replaces the deprecated `changeEditorInterface` method with `changeFieldControl`. API signature changed slightly (one more parameter added - for this tool it will always be `builtin`).

I updated the tests as well.

Fixes #81 