### PR TITLE
Add support for template customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Contentful Migrate Tool
 
-[![npm](https://img.shields.io/npm/v/contentful-migrate.svg)](https://www.npmjs.com/package/contentful-migrate)
-[![contentful-migration version](https://img.shields.io/npm/dependency-version/contentful-migrate/contentful-migration)](https://www.npmjs.com/package/contentful-migration)
-[![Build Status](https://github.com/deluan/contentful-migrate/workflows/CI/badge.svg)](https://github.com/deluan/contentful-migrate/actions)
-[![Downloads](https://img.shields.io/npm/dm/contentful-migrate)](https://www.npmjs.com/package/contentful-migrate)
+[![npm](https://img.shields.io/npm/v/contentful-migrate-fork.svg)](https://www.npmjs.com/package/contentful-migrate-fork)
+[![contentful-migration version](https://img.shields.io/npm/dependency-version/contentful-migrate-fork/contentful-migration)](https://www.npmjs.com/package/contentful-migration)
+[![Build Status](https://github.com/devlato/contentful-migrate-fork/workflows/CI/badge.svg)](https://github.com/devlato/contentful-migrate-fork/actions)
+[![Downloads](https://img.shields.io/npm/dm/contentful-migrate-fork)](https://www.npmjs.com/package/contentful-migrate-fork)
 
 Manage your Contentful schema by creating incremental scripted changes. This project is based on the ideas exposed
 in [Contentful's CMS as Code article](https://www.contentful.com/r/knowledgebase/cms-as-code/)

--- a/README.md
+++ b/README.md
@@ -119,10 +119,12 @@ Creates an empty time stamped file in the content-type's migrations folder.
   Options:
 
     -c, --content-type <content-type>  content type name
+    -t, --migration-template <migration-template>  migration file template path
+    -e, --extension <extension>  generated migration file extension
 ```
 
-Example: executing the command `ctf-migrate create create-post-model -c post` will create
-a file named `./migrations/post/1513695986378-create-post.js` (the timestamp will vary)
+Example: executing the command `ctf-migrate create create-post-model -c post -t template.ts -e .ts` will create
+a file named `./migrations/post/1513695986378-create-post.ts` (the timestamp will vary)
 
 ### list
 

--- a/bin/commands/create.js
+++ b/bin/commands/create.js
@@ -20,22 +20,49 @@ exports.builder = (yargs) => {
       requiresArg: true,
       demandOption: true
     })
+    .option('template-file', {
+      alias: 't',
+      describe: 'template file path',
+      type: 'string',
+      requiresArg: true,
+      demandOption: false
+    })
+    .option('extension', {
+      alias: 'e',
+      describe: 'migration file extension',
+      type: 'string',
+      requiresArg: true,
+      demandOption: false
+    })
     .positional('name', {
       describe: 'descriptive name for the migration file',
       type: 'string'
     })
 }
 
-exports.handler = ({ name, contentType }) => {
+exports.handler = ({ name, contentType, templateFile, extension }) => {
   const migrationsDirectory = path.join('.', 'migrations', contentType)
-  const templateFile = path.join(__dirname, '..', '..', 'lib', 'template.js')
+  templateFile = !!templateFile
+    ? path.isAbsolute(templateFile) 
+      ? templateFile
+      : path.join(process.cwd(), templateFile)
+    : !!process.env.TEMPLATE_FILE && typeof process.env.TEMPLATE_FILE === 'string'
+      ? path.isAbsolute(process.env.TEMPLATE_FILE) 
+        ? process.env.TEMPLATE_FILE
+        : path.join(__dirname, process.env.TEMPLATE_FILE)
+      : path.join(__dirname, '..', '..', 'lib', 'template.js')
+  extension = !!extension
+    ? extension
+    : !!process.env.MIGRATION_FILE_EXTENSION && typeof process.env.MIGRATION_FILE_EXTENSION === 'string'
+      ? process.env.MIGRATION_FILE_EXTENSION
+      : '.js'
 
   generator({
     name,
     templateFile,
     migrationsDirectory,
     dateFormat: 'UTC:yyyymmddHHMMss',
-    extension: '.js'
+    extension: extension
   }, (error, filename) => {
     if (error) {
       log(chalk.bold.red(`🚨 Template generation error ${error.message}`))

--- a/bin/commands/create.js
+++ b/bin/commands/create.js
@@ -49,7 +49,7 @@ exports.handler = ({ name, contentType, templateFile, extension }) => {
     : !!process.env.TEMPLATE_FILE && typeof process.env.TEMPLATE_FILE === 'string'
       ? path.isAbsolute(process.env.TEMPLATE_FILE) 
         ? process.env.TEMPLATE_FILE
-        : path.join(__dirname, process.env.TEMPLATE_FILE)
+        : path.join(process.cwd(), process.env.TEMPLATE_FILE)
       : path.join(__dirname, '..', '..', 'lib', 'template.js')
   extension = !!extension
     ? extension

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
-  "name": "contentful-migrate",
+  "name": "contentful-migrate-fork",
   "version": "0.13.0",
-  "description": "Migration tooling for Contentful, with state management",
+  "description": "Migration tooling for Contentful, with state management and custom templates support",
   "keywords": [
     "migrate",
     "migrations",
     "contentful",
-    "cms-as-code"
+    "cms-as-code",
+    "typescript"
   ],
   "engines": {
     "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -29,17 +29,18 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deluan/contentful-migrate.git"
+    "url": "git+https://github.com/devlato/contentful-migrate.git"
   },
   "contributors": [
+    "Denis Tokarev",
     "Deluan Quintao",
     "Jerry Ma"
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/deluan/contentful-migrate/issues"
+    "url": "https://github.com/devlato/contentful-migrate/issues"
   },
-  "homepage": "https://github.com/deluan/contentful-migrate#readme",
+  "homepage": "https://github.com/devlato/contentful-migrate#readme",
   "devDependencies": {
     "expect.js": "^0.3.1",
     "growl": "^1.10.5",


### PR DESCRIPTION
This PR addresses an [issue with missing support for generating migrations in TypeScript](https://github.com/deluan/contentful-migrate/issues/53) by introducing new options and/or environment variables for customizing the migration template file and generated migration file extension, for the `create` command.

The new options are:
* `--migration-template` / `-t` – specifies a template file. If a relative path provided, it will be resolved relative to the current working directory. It also can be set using `TEMPLATE_FILE` environment variable.
* `--extension` / `-e` – specifies an extension for a generated migration file.  It also can be set using `MIGRATION_FILE_EXTENSION` environment variable.

A working demo is available as a fork of this library, named [contentful-migrate-fork](https://npmjs.com/package/contentful-migrate-fork).
