### PR TITLE
Allow persistent default values for space-id & env-id using environment vars

### DIFF
--- a/bin/commands/bootstrap.js
+++ b/bin/commands/bootstrap.js
@@ -27,14 +27,17 @@ exports.builder = (yargs) => {
       describe: 'space id to use',
       type: 'string',
       requiresArg: true,
-      demandOption: true
+      demandOption: true,
+      default: process.env.CONTENTFUL_SPACE_ID,
+      defaultDescription: 'environment var CONTENTFUL_SPACE_ID'
     })
     .option('environment-id', {
       alias: 'e',
       describe: 'id of the environment within the space',
       type: 'string',
       requiresArg: true,
-      default: 'master'
+      default: process.env.CONTENTFUL_ENV_ID || 'master',
+      defaultDescription: 'environment var CONTENTFUL_ENV_ID if exists, otherwise master'
     })
     .option('content-type', {
       alias: 'c',

--- a/bin/commands/down.js
+++ b/bin/commands/down.js
@@ -26,14 +26,17 @@ exports.builder = (yargs) => {
       describe: 'space id to use',
       type: 'string',
       requiresArg: true,
-      demandOption: true
+      demandOption: true,
+      default: process.env.CONTENTFUL_SPACE_ID,
+      defaultDescription: 'environment var CONTENTFUL_SPACE_ID'
     })
     .option('environment-id', {
       alias: 'e',
       describe: 'id of the environment within the space',
       type: 'string',
       requiresArg: true,
-      default: 'master'
+      default: process.env.CONTENTFUL_ENV_ID || 'master',
+      defaultDescription: 'environment var CONTENTFUL_ENV_ID if exists, otherwise master'
     })
     .option('content-type', {
       alias: 'c',

--- a/bin/commands/init.js
+++ b/bin/commands/init.js
@@ -23,14 +23,17 @@ exports.builder = (yargs) => {
       describe: 'space id to use',
       type: 'string',
       requiresArg: true,
-      demandOption: true
+      demandOption: true,
+      default: process.env.CONTENTFUL_SPACE_ID,
+      defaultDescription: 'environment var CONTENTFUL_SPACE_ID'
     })
     .option('environment-id', {
       alias: 'e',
       describe: 'id of the environment within the space',
       type: 'string',
       requiresArg: true,
-      default: 'master'
+      default: process.env.CONTENTFUL_ENV_ID || 'master',
+      defaultDescription: 'environment var CONTENTFUL_ENV_ID if exists, otherwise master'
     })
 }
 

--- a/bin/commands/list.js
+++ b/bin/commands/list.js
@@ -27,14 +27,17 @@ exports.builder = (yargs) => {
       describe: 'space id to use',
       type: 'string',
       requiresArg: true,
-      demandOption: true
+      demandOption: true,
+      default: process.env.CONTENTFUL_SPACE_ID,
+      defaultDescription: 'environment var CONTENTFUL_SPACE_ID'
     })
     .option('environment-id', {
       alias: 'e',
       describe: 'id of the environment within the space',
       type: 'string',
       requiresArg: true,
-      default: 'master'
+      default: process.env.CONTENTFUL_ENV_ID || 'master',
+      defaultDescription: 'environment var CONTENTFUL_ENV_ID if exists, otherwise master'
     })
     .option('content-type', {
       alias: 'c',

--- a/bin/commands/up.js
+++ b/bin/commands/up.js
@@ -30,14 +30,17 @@ exports.builder = (yargs) => {
       describe: 'space id to use',
       type: 'string',
       requiresArg: true,
-      demandOption: true
+      demandOption: true,
+      default: process.env.CONTENTFUL_SPACE_ID,
+      defaultDescription: 'environment var CONTENTFUL_SPACE_ID'
     })
     .option('environment-id', {
       alias: 'e',
       describe: 'id of the environment within the space',
       type: 'string',
       requiresArg: true,
-      default: 'master'
+      default: process.env.CONTENTFUL_ENV_ID || 'master',
+      defaultDescription: 'environment var CONTENTFUL_ENV_ID if exists, otherwise master'
     })
     .option('content-type', {
       alias: 'c',


### PR DESCRIPTION
Similar to how the access token can already be specified via environment variable, this PR allows a user who will often be working in the same contentful space / environment to specify these defaults using env vars.