### PR TITLE
Make migrations directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ your-project
 
 ```
 
+If you don't wish to have your migrations directory in the root of your project, you can configure the name and location by setting the CONTENTFUL_MIGRATION_DIR environment variable.
+
 For more information on schema migrations technique and practice, see:
 
 - [Evolutionary Database Design](https://martinfowler.com/articles/evodb.html)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ your-project
 
 ```
 
-If you don't wish to have your migrations directory in the root of your project, you can configure the name and location by setting the CONTENTFUL_MIGRATION_DIR environment variable.
+If you don't wish to have your migrations directory in the root of your project, you can configure the name and location by setting the CONTENTFUL_MIGRATION_DIR environment variable, e.g. `/path/to/project/foo/contentful-migrations`
 
 For more information on schema migrations technique and practice, see:
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ your-project
 
 If you don't wish to have your migrations directory in the root of your project, you can configure the name and location by setting the CONTENTFUL_MIGRATION_DIR environment variable, e.g. `/path/to/project/foo/contentful-migrations`
 
+> **ATTENTION**: The migrations directory should always be a folder under the project's root (or under some subdir inside the root). Placing the directory outside of the project's version control could lead to the migration code and Contentful schema becoming out-of-sync.
+
 For more information on schema migrations technique and practice, see:
 
 - [Evolutionary Database Design](https://martinfowler.com/articles/evodb.html)

--- a/bin/commands/bootstrap.js
+++ b/bin/commands/bootstrap.js
@@ -84,7 +84,7 @@ exports.handler = async (args) => {
     })
   }
 
-  const migrationsDirectory = path.join('.', 'migrations')
+  const migrationsDirectory = process.env.CONTENTFUL_MIGRATIONS_DIR || path.join('.', 'migrations')
   let writeMigrationState = false
   if (contentType.length > 0) {
     const answer = await asyncQuestion(chalk.bold.yellow(`⚠️   Do you want to generate initial migration state for ${contentType}? y/N: `))

--- a/bin/commands/create.js
+++ b/bin/commands/create.js
@@ -27,7 +27,10 @@ exports.builder = (yargs) => {
 }
 
 exports.handler = ({ name, contentType }) => {
-  const migrationsDirectory = path.join('.', 'migrations', contentType)
+  const migrationsDirectory = process.env.CONTENTFUL_MIGRATIONS_DIR
+    ? path.join(process.env.CONTENTFUL_MIGRATIONS_DIR, contentType)
+    : path.join('.', 'migrations', contentType)
+
   const templateFile = path.join(__dirname, '..', '..', 'lib', 'template.js')
 
   generator({

--- a/bin/commands/down.js
+++ b/bin/commands/down.js
@@ -65,7 +65,7 @@ exports.handler = async (args) => {
     spaceId
   } = args
 
-  const migrationsDirectory = path.join('.', 'migrations')
+  const migrationsDirectory = process.env.CONTENTFUL_MIGRATIONS_DIR || path.join('.', 'migrations')
 
   const processSet = (set) => {
     const name = (file) || set.lastRun

--- a/bin/commands/list.js
+++ b/bin/commands/list.js
@@ -64,7 +64,7 @@ exports.builder = (yargs) => {
 exports.handler = async ({
   spaceId, environmentId, contentType, accessToken
 }) => {
-  const migrationsDirectory = path.join('.', 'migrations')
+  const migrationsDirectory = process.env.CONTENTFUL_MIGRATIONS_DIR || path.join('.', 'migrations')
 
   const listSet = (set) => {
     // eslint-disable-next-line no-console

--- a/bin/commands/up.js
+++ b/bin/commands/up.js
@@ -89,7 +89,7 @@ exports.handler = async (args) => {
     spaceId
   } = args
 
-  const migrationsDirectory = path.join('.', 'migrations')
+  const migrationsDirectory = process.env.CONTENTFUL_MIGRATIONS_DIR || path.join('.', 'migrations')
 
   const processSet = async (set) => {
     console.log(chalk.bold.blue('Processing'), set.store.contentTypeID)

--- a/lib/bootstrap/createFile.js
+++ b/lib/bootstrap/createFile.js
@@ -19,7 +19,7 @@ const createFile = (contentTypeId, fileContent, migrationsDirectory) => {
       // Fix up file path
       const date = dateformat(new Date(), 'UTC:yyyymmddHHMMss')
       const fileName = `${date}-create-${camelToDash(contentTypeId)}.js`
-      const filePath = path.join(process.cwd(), directory, fileName)
+      const filePath = path.join(directory, fileName)
 
       // Write the template file
       return fs.writeFile(filePath, fileContent, (writeFileError) => {

--- a/lib/bootstrap/deleteScripts.js
+++ b/lib/bootstrap/deleteScripts.js
@@ -10,9 +10,9 @@ const deleteScripts = (migrationsDirectory, contentTypes) => {
         const contentTypeDirectory = path.join(migrationsDirectory, contentType)
         return rimraf(contentTypeDirectory, (error) => {
           if (error) {
-            reject(logError(`🚨   Failed to delete migrations/${contentType} folder`, error))
+            reject(logError(`🚨   Failed to delete ${contentTypeDirectory} folder`, error))
           }
-          resolve(log(`migrations/${contentType} folder`, 'deleted'))
+          resolve(log(`${contentTypeDirectory} folder`, 'deleted'))
         })
       })
     })


### PR DESCRIPTION
These changes allow the user to have the migrations directory somewhere other than the project root, and allow for a directory name other than "migrations" by setting the fully qualified path to the desired migrations directory in the CONTENTFUL_MIGRATIONS_DIR environment variable.