### PR TITLE
[BUG] Environment: undefined in migration CLI summary 

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -77,7 +77,7 @@ const run = async ({
     await writeErrorsToLog.default(parseResult.getRuntimeErrors(), errorsFile)
     process.exit(1)
   }
-  await renderMigration.renderPlan(batches)
+  await renderMigration.renderPlan(batches, environmentId)
   const serverErrorsWritten = []
   const tasks = batches.map((batch) => {
     return {


### PR DESCRIPTION
## Description
Noticed that when running migrations that the Environment chalk label was returning undefined. 

![CleanShot 2020-12-27 at 23 11 54@2x](https://user-images.githubusercontent.com/122406/103196576-48973f80-4899-11eb-89ee-3759214ac7fa.png)

## Solution
adding environmentId to renderPlan() on the renderMigration async call. renderPlan() expects the environmentId be set when using it. since we know environmentId is either CONTENTFUL_ENV_ID  env variable or "master" its safe to pass directly here. 

