### PR TITLE
fix: breaking eslint config when running migrate script

### DIFF
--- a/lib/bootstrap/jsonToScript.js
+++ b/lib/bootstrap/jsonToScript.js
@@ -68,7 +68,7 @@ const jsonToScript = (contentTypeJson, editorInterface) => {
   const unformattedScript = createScript(restructuredJson, editorInterface)
   const engine = new eslint.CLIEngine({
     fix: true,
-    baseConfig: { extends: ['eslint-config-standard'] },
+    baseConfig: { extends: ['standard'] },
     useEslintrc: false
   })
   return engine.executeOnText(unformattedScript).results[0].output

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contentful-migrate",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Migration tooling for Contentful, with state management",
   "keywords": [
     "migrate",


### PR DESCRIPTION
Got the error when running `ctf-migrate bootstrap`.  The config that's extending is not valid. 

Error I got:
```javascript
  🚨  Failed to perform bootstrap : Error: Failed to load config "eslint-config-standard" to extend from.
Referenced from: BaseConfig
Error: Failed to load config "eslint-config-standard" to extend from.
Referenced from: BaseConfig
```