### PR TITLE
Bump contentful-migration dep to 4.12.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "chalk": "^3.0.0",
     "contentful-management": "^7.11.0",
-    "contentful-migration": "^4.5.0",
+    "contentful-migration": "^4.12.6",
     "dateformat": "^3.0.3",
     "eslint": "^6.8.0",
     "eslint-config-standard": "^14.1.0",


### PR DESCRIPTION
Contentful has added subscript and superscript support to its Rich Text editor, including support for it via migration scripting via contentful-migration in v4.12.6.

Currently, running contentful-migrate with `enabledMarks` of `superscript` or `subscript` will fail, since its contentful-migration dependent version doesn't contain this support.